### PR TITLE
Add GitHub ci-workflow action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Build and Test
 
 on: [push]
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,17 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  test:
+    name: Test on Node 12.x on Ubuntu linux
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: yarn install
+    - run: yarn run check
+      env:
+        CI: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.vscode
+build
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/mcode/covid-19-pui/workflows/Build%20and%20Test/badge.svg)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test-no-watch": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
     "lint": "eslint './src/**/*.js'",
-    "lint-fix": "eslint './src/**/*.js' --fix"
+    "lint-fix": "eslint './src/**/*.js' --fix",
+    "prettier": "prettier --check \"**/*.{js,jsx}\"",
+    "prettier-fix": "prettier --write \"**/*.{js,jsx}\"",
+    "check": "npm run build && npm run test-no-watch && npm run lint && npm run prettier"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "test": "react-scripts test",
     "test-no-watch": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
-    "lint": "eslint './src/**/*.js'",
-    "lint-fix": "eslint './src/**/*.js' --fix",
-    "prettier": "prettier --check \"**/*.{js,jsx}\"",
-    "prettier-fix": "prettier --write \"**/*.{js,jsx}\"",
+    "lint": "eslint './src/**/*.{js,jsx}'",
+    "lint-fix": "eslint './src/**/*.{js,jsx}' --fix",
+    "prettier": "prettier --check '**/*.{js,jsx}'",
+    "prettier-fix": "prettier --write '**/*.{js,jsx}'",
     "check": "npm run build && npm run test-no-watch && npm run lint && npm run prettier"
   },
   "eslintConfig": {


### PR DESCRIPTION
The ci-workflow action will:
- install dependencies
- build the app
- run the tests
- run the linter
- check the style (prettier)

This also adds an npm script called `check` that will run the same tests as the ci-workflow.  This allows developers to test their branch locally before pushing to GitHub.

See the run (on this very branch!) here: https://github.com/mcode/covid-19-pui/runs/517517453?check_suite_focus=true