### PR TITLE
Add header component for form sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "IE 11"
     ]
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,11 +6,13 @@ import FormContent from './components/FormContent';
 
 function App() {
   return (
-    <Grid container direction="column">
-      <Grid item xs={12}>
-        <PageHeader />
+    <>
+      <Grid container>
+        <Grid item xs={12}>
+          <PageHeader />
+        </Grid>
       </Grid>
-      <Grid item container direction="row">
+      <Grid container direction="row">
         <Grid item xs={3}>
           <Navigation />
         </Grid>
@@ -18,7 +20,7 @@ function App() {
           <FormContent />
         </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 }
 

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import FormSectionHeader from '../FormSectionHeader';
+
+const sections = [
+  { id: 'identifiers', title: 'IDENTIFIERS' },
+  { id: 'interviewer', title: 'INTERVIEWER' },
+  { id: 'basicInformation', title: 'BASIC INFORMATION' },
+  { id: 'demographics', title: 'DEMOGRAPHICS' },
+  { id: 'diseaseInformation', title: 'DISEASE INFORMATION' }
+];
 
 function FormContent() {
-  return <div>Form content goes here</div>;
+  return sections.map(s => <FormSectionHeader key={s.id} title={s.title} />);
 }
 
 export default FormContent;

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Grid, makeStyles } from '@material-ui/core';
+
+const borderColor = '#404040';
+const useStyles = makeStyles({
+  titleBox: {
+    fontFamily: 'Avenir Next',
+    backgroundColor: borderColor,
+    color: 'white',
+    border: `3px solid ${borderColor}`,
+    letterSpacing: 1,
+    display: 'inline-block'
+  },
+  line: {
+    display: 'inline-block',
+    border: `1px solid ${borderColor}`,
+    width: '100%'
+  }
+});
+
+function FormSectionHeader({ title }) {
+  const classes = useStyles();
+
+  return (
+    <Grid container direction="row">
+      <Grid item>
+        <div className={classes.titleBox}>{title}</div>
+      </Grid>
+      <Grid item xs={9}>
+        <div className={classes.line}></div>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default FormSectionHeader;

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -4,7 +4,7 @@ import { Box, makeStyles } from '@material-ui/core';
 const borderColor = '#404040';
 const useStyles = makeStyles({
   titleBox: {
-    fontFamily: 'Avenir Next',
+    fontFamily: 'Avenir Next, Segoe UI, Roboto, Helvetica Neue, sans-serif',
     fontWeight: 500,
     backgroundColor: borderColor,
     color: 'white',

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { Grid, makeStyles } from '@material-ui/core';
+import { Box, makeStyles } from '@material-ui/core';
 
 const borderColor = '#404040';
 const useStyles = makeStyles({
   titleBox: {
     fontFamily: 'Avenir Next',
+    fontWeight: 500,
     backgroundColor: borderColor,
     color: 'white',
     border: `3px solid ${borderColor}`,
     letterSpacing: 1,
-    display: 'inline-block'
+    display: 'inline-block',
+    padding: '0 5px'
   },
   line: {
     display: 'inline-block',
@@ -19,17 +21,15 @@ const useStyles = makeStyles({
 });
 
 function FormSectionHeader({ title }) {
-  const classes = useStyles();
+  const styles = useStyles();
 
   return (
-    <Grid container direction="row">
-      <Grid item>
-        <div className={classes.titleBox}>{title}</div>
-      </Grid>
-      <Grid item xs={9}>
-        <div className={classes.line}></div>
-      </Grid>
-    </Grid>
+    <Box display="flex" flexDirection="row">
+      <Box className={styles.titleBox}>{title}</Box>
+      <Box flexGrow={1}>
+        <div className={styles.line}></div>
+      </Box>
+    </Box>
   );
 }
 

--- a/src/components/FormSectionHeader/__tests__/FormSectionHeader.test.jsx
+++ b/src/components/FormSectionHeader/__tests__/FormSectionHeader.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import FormSectionHeader from '../FormSectionHeader';
+
+test('renders form section header with title', () => {
+  const mockTitle = 'Example';
+  const { getByText } = render(<FormSectionHeader title={mockTitle} />);
+
+  const titleElement = getByText(mockTitle);
+  expect(titleElement).toBeInTheDocument();
+});

--- a/src/components/FormSectionHeader/index.js
+++ b/src/components/FormSectionHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormSectionHeader';


### PR DESCRIPTION
# Summary

Adds a component for the header of each form section, shown in the mockups:
![image](https://user-images.githubusercontent.com/16297930/77009053-a7f51600-693d-11ea-9e50-b2b623ca7692.png)

I also rendered headers for all current sections we have mocked up. Resolves #7 

## Code Changes

* New component, `FormSectionHeader` which renders the given title and a dividing line
  * Included a test that asserts the presence of said title in the document
* Updated `FormContent` component to render headers for all the sections in the mockups (no content yet)

## Testing Guidance

Run tests and lint. Start app and look at the layout/style of the headers