### PR TITLE
Add sidebar for navigating between sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@testing-library/user-event": "^7.1.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
-    "react-scripts": "3.4.0"
+    "react-scripts": "3.4.0",
+    "tocbot": "^4.10.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,10 +13,10 @@ function App() {
         </Grid>
       </Grid>
       <Grid container direction="row">
-        <Grid item xs={3}>
+        <Grid item xs={2}>
           <Navigation />
         </Grid>
-        <Grid className="tocSection" item xs={9}>
+        <Grid className="tocSection" item xs={10}>
           <FormContent />
         </Grid>
       </Grid>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
+import clsx from 'clsx';
 import PageHeader from './components/PageHeader';
 import Navigation from './components/Navigation';
 import FormContent from './components/FormContent';
 
+const useStyles = makeStyles({
+  content: {
+    marginLeft: '265px' // TODO: move to theme
+  }
+});
+
 function App() {
+  const styles = useStyles();
+
   return (
     <>
       <Grid container>
@@ -12,14 +21,10 @@ function App() {
           <PageHeader />
         </Grid>
       </Grid>
-      <Grid container direction="row">
-        <Grid item xs={2}>
-          <Navigation />
-        </Grid>
-        <Grid className="tocSection" item xs={10}>
-          <FormContent />
-        </Grid>
-      </Grid>
+      <Navigation />
+      <div className={clsx(styles.content, 'tocSection')}>
+        <FormContent />
+      </div>
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
         <Grid item xs={3}>
           <Navigation />
         </Grid>
-        <Grid item xs={9}>
+        <Grid className="tocSection" item xs={9}>
           <FormContent />
         </Grid>
       </Grid>

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { updateTOC, cleanUpTOC } from '../Navigation/Navigation';
 import FormSectionHeader from '../FormSectionHeader';
 
 const sections = [
@@ -10,6 +11,11 @@ const sections = [
 ];
 
 function FormContent() {
+  useEffect(() => {
+    updateTOC();
+    return cleanUpTOC;
+  });
+
   return sections.map(s => <FormSectionHeader key={s.id} title={s.title} />);
 }
 

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -16,7 +16,7 @@ function FormContent() {
     return cleanUpTOC;
   });
 
-  return sections.map(s => <FormSectionHeader key={s.id} title={s.title} />);
+  return sections.map(s => <FormSectionHeader id={s.id} key={s.id} title={s.title} />);
 }
 
 export default FormContent;

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -3,11 +3,11 @@ import { updateTOC, cleanUpTOC } from '../Navigation/Navigation';
 import FormSectionHeader from '../FormSectionHeader';
 
 const sections = [
-  { id: 'identifiers', title: 'IDENTIFIERS' },
-  { id: 'interviewer', title: 'INTERVIEWER' },
-  { id: 'basicInformation', title: 'BASIC INFORMATION' },
-  { id: 'demographics', title: 'DEMOGRAPHICS' },
-  { id: 'diseaseInformation', title: 'DISEASE INFORMATION' }
+  { id: 'identifiers', title: 'identifiers' },
+  { id: 'interviewer', title: 'interviewer' },
+  { id: 'basicInformation', title: 'basic information' },
+  { id: 'demographics', title: 'demographics' },
+  { id: 'diseaseInformation', title: 'disease information' }
 ];
 
 function FormContent() {

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -32,7 +32,7 @@ function FormContent() {
   });
 
   return sections.map(s => (
-    <div className={styles.root}>
+    <div className={styles.root} key={s.id}>
       <FormSectionHeader id={s.id} key={s.id} title={s.title} />
     </div>
   ));

--- a/src/components/FormContent/__tests__/FormContent.test.jsx
+++ b/src/components/FormContent/__tests__/FormContent.test.jsx
@@ -2,6 +2,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import FormContent from '../FormContent';
 
+const MockTOC = () => {
+  return <div className="toc"></div>;
+};
+
 test('renders form content', () => {
-  render(<FormContent />);
+  render(
+    <div>
+      <MockTOC />
+      <div className="tocSection">
+        <FormContent />
+      </div>
+    </div>
+  );
 });

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -21,12 +21,12 @@ const useStyles = makeStyles({
   }
 });
 
-function FormSectionHeader({ title }) {
+function FormSectionHeader({ title, id }) {
   const styles = useStyles();
 
   return (
     <Box display="flex" flexDirection="row">
-      <Box className={clsx(styles.titleBox, 'tocHeading')}>{title}</Box>
+      <Box id={id} className={clsx(styles.titleBox, 'tocHeading')}>{title}</Box>
       <Box flexGrow={1}>
         <div className={styles.line}></div>
       </Box>

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, makeStyles } from '@material-ui/core';
+import clsx from 'clsx';
 
 const borderColor = '#404040';
 const useStyles = makeStyles({
@@ -25,7 +26,7 @@ function FormSectionHeader({ title }) {
 
   return (
     <Box display="flex" flexDirection="row">
-      <Box className={styles.titleBox}>{title}</Box>
+      <Box className={clsx(styles.titleBox, 'tocHeading')}>{title}</Box>
       <Box flexGrow={1}>
         <div className={styles.line}></div>
       </Box>

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -13,7 +13,8 @@ const useStyles = makeStyles({
     letterSpacing: 1,
     display: 'inline-block',
     padding: '0 5px',
-    textTransform: 'uppercase'
+    textTransform: 'uppercase',
+    marginBottom: '30em'
   },
   line: {
     display: 'inline-block',

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -12,7 +12,8 @@ const useStyles = makeStyles({
     border: `3px solid ${borderColor}`,
     letterSpacing: 1,
     display: 'inline-block',
-    padding: '0 5px'
+    padding: '0 5px',
+    textTransform: 'uppercase'
   },
   line: {
     display: 'inline-block',

--- a/src/components/FormSectionHeader/FormSectionHeader.jsx
+++ b/src/components/FormSectionHeader/FormSectionHeader.jsx
@@ -26,7 +26,9 @@ function FormSectionHeader({ title, id }) {
 
   return (
     <Box display="flex" flexDirection="row">
-      <Box id={id} className={clsx(styles.titleBox, 'tocHeading')}>{title}</Box>
+      <Box id={id} className={clsx(styles.titleBox, 'tocHeading')}>
+        {title}
+      </Box>
       <Box flexGrow={1}>
         <div className={styles.line}></div>
       </Box>

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -50,7 +50,7 @@ function Navigation() {
   const [classNames, setClassNames] = useState(clsx('toc', styles.toc));
   const scrollListener = useCallback(
     element => {
-      const distanceToTop = element.getBoundingClientRect().top;
+      const distanceToTop = element?.getBoundingClientRect().top;
       const elementListener = () => {
         distanceToTop - document.documentElement.scrollTop <= 0
           ? setClassNames(clsx('toc', styles.toc, styles.makeSticky))

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -36,6 +36,10 @@ const useStyles = makeStyles({
         }
       }
     }
+  },
+  makeSticky: {
+    // position: 'fixed',
+    // top: '0'
   }
 });
 
@@ -47,7 +51,7 @@ function Navigation() {
       const elementListener = () => {
         const top = element.getBoundingClientRect().top;
         top <= 0
-          ? setClassNames(clsx('toc', styles.toc, 'makeSticky'))
+          ? setClassNames(clsx('toc', styles.toc, styles.makeSticky))
           : setClassNames(clsx('toc', styles.toc));
       };
       window.addEventListener('scroll', elementListener);
@@ -55,7 +59,7 @@ function Navigation() {
         window.removeEventListener('scroll', elementListener);
       };
     },
-    [styles.toc]
+    [styles]
   );
   return <div ref={scrollListener} className={classNames}></div>;
 }

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -38,8 +38,8 @@ const useStyles = makeStyles({
     }
   },
   makeSticky: {
-    // position: 'fixed',
-    // top: '0'
+    position: 'fixed',
+    top: '0'
   }
 });
 
@@ -48,9 +48,9 @@ function Navigation() {
   const [classNames, setClassNames] = useState(clsx('toc', styles.toc));
   const scrollListener = useCallback(
     element => {
+      const distanceToTop = element.getBoundingClientRect().top;
       const elementListener = () => {
-        const top = element.getBoundingClientRect().top;
-        top <= 0
+        distanceToTop - document.documentElement.scrollTop <= 0
           ? setClassNames(clsx('toc', styles.toc, styles.makeSticky))
           : setClassNames(clsx('toc', styles.toc));
       };

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -10,11 +10,14 @@ const useStyles = makeStyles({
     position: 'sticky',
     top: '0',
     paddingTop: '0.5em',
+    paddingRight: '1em',
+    width: 'fit-content',
     '@global': {
       ol: {
         listStyle: 'none',
         fontFamily: 'Avenir Next',
         fontWeight: 500,
+        paddingLeft: '1.5em',
         '@global li': {
           marginBottom: '0.25em'
         },

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -11,7 +11,6 @@ const useStyles = makeStyles({
     top: '0',
     paddingTop: '0.5em',
     paddingRight: '1em',
-    width: 'fit-content',
     '@global': {
       ol: {
         listStyle: 'none',

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,8 +1,33 @@
 import React from 'react';
+import clsx from 'clsx';
+import { makeStyles } from '@material-ui/core/styles';
 import tocbot from 'tocbot';
 
+const useStyles = makeStyles({
+  toc: {
+    background: '#d8d8d8',
+    height: '100vh',
+    position: 'fixed',
+    '@global': {
+      ol: {
+        listStyle: 'none',
+        fontFamily: 'Avenir Next',
+        fontWeight: 500,
+        '@global li': {
+          marginBottom: '0.25em'
+        },
+        '@global a': {
+          color: '#404040',
+          textDecoration: 'none'
+        }
+      }
+    }
+  }
+});
+
 function Navigation() {
-  return <div className="toc"></div>;
+  const styles = useStyles();
+  return <div className={clsx('toc', styles.toc)}></div>;
 }
 
 function updateTOC() {

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -9,8 +9,8 @@ function updateTOC() {
   // Initialize Tocbot
   tocbot.init({
     tocSelector: '.toc',
-    contentSelector: '.tocHeading',
-    headingSelector: 'h1'
+    contentSelector: '.tocSection',
+    headingSelector: '.tocHeading'
   });
 }
 

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -47,8 +47,6 @@ function Navigation() {
           ? setClassNames(clsx('toc', styles.toc, 'makeSticky'))
           : setClassNames(clsx('toc', styles.toc));
       };
-      console.log('asdf');
-      console.log(element.getBoundingClientRect().top);
       window.addEventListener('scroll', elementListener);
       return () => {
         window.removeEventListener('scroll', elementListener);

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -7,7 +7,9 @@ const useStyles = makeStyles({
   toc: {
     background: '#d8d8d8',
     height: '100vh',
-    position: 'fixed',
+    position: 'sticky',
+    top: '0',
+    paddingTop: '0.5em',
     '@global': {
       ol: {
         listStyle: 'none',

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -10,6 +10,8 @@ const useStyles = makeStyles({
     position: 'sticky',
     top: '0',
     paddingRight: '1em',
+    width: '265px',
+    float: 'left',
     '@global': {
       ol: {
         listStyle: 'none',

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -18,13 +18,19 @@ const useStyles = makeStyles({
         fontWeight: 500,
         paddingLeft: '1.5em',
         textTransform: 'capitalize',
-        '@global li': {
-          marginBottom: '0.25em'
-        },
-        '@global a': {
-          color: '#404040',
-          textDecoration: 'none'
+        '@global': {
+          li: {
+            marginBottom: '0.25em'
+          },
+          a: {
+            color: '#404040',
+            textDecoration: 'none'
+          }
         }
+      },
+      '.activeHeading': {
+        borderLeft: '0.1em solid',
+        paddingLeft: '0.5em'
       }
     }
   }
@@ -40,7 +46,8 @@ function updateTOC() {
   tocbot.init({
     tocSelector: '.toc',
     contentSelector: '.tocSection',
-    headingSelector: '.tocHeading'
+    headingSelector: '.tocHeading',
+    activeLinkClass: 'activeHeading'
   });
 }
 

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,7 +1,22 @@
 import React from 'react';
+import tocbot from 'tocbot';
 
 function Navigation() {
-  return <div>Navigation goes here</div>;
+  return <div className="toc"></div>;
+}
+
+function updateTOC() {
+  // Initialize Tocbot
+  tocbot.init({
+    tocSelector: '.toc',
+    contentSelector: '.tocHeading',
+    headingSelector: 'h1'
+  });
+}
+
+function cleanUpTOC() {
+  tocbot.destroy();
 }
 
 export default Navigation;
+export { updateTOC, cleanUpTOC };

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core/styles';
 import tocbot from 'tocbot';
@@ -38,7 +38,25 @@ const useStyles = makeStyles({
 
 function Navigation() {
   const styles = useStyles();
-  return <div className={clsx('toc', styles.toc)}></div>;
+  const [classNames, setClassNames] = useState(clsx('toc', styles.toc));
+  const scrollListener = useCallback(
+    element => {
+      const elementListener = () => {
+        const top = element.getBoundingClientRect().top;
+        top <= 0
+          ? setClassNames(clsx('toc', styles.toc, 'makeSticky'))
+          : setClassNames(clsx('toc', styles.toc));
+      };
+      console.log('asdf');
+      console.log(element.getBoundingClientRect().top);
+      window.addEventListener('scroll', elementListener);
+      return () => {
+        window.removeEventListener('scroll', elementListener);
+      };
+    },
+    [styles.toc]
+  );
+  return <div ref={scrollListener} className={classNames}></div>;
 }
 
 function updateTOC() {

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles({
         fontFamily: 'Avenir Next',
         fontWeight: 500,
         paddingLeft: '1.5em',
+        textTransform: 'capitalize',
         '@global li': {
           marginBottom: '0.25em'
         },

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
     '@global': {
       ol: {
         listStyle: 'none',
-        fontFamily: 'Avenir Next',
+        fontFamily: '"Avenir Next", "Segoe UI", "Roboto", "Helvetica Neue", sans-serif',
         fontWeight: 500,
         paddingLeft: '1.5em',
         textTransform: 'capitalize',

--- a/src/components/Navigation/__tests__/Navigation.test.jsx
+++ b/src/components/Navigation/__tests__/Navigation.test.jsx
@@ -1,7 +1,44 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { render } from '@testing-library/react';
-import Navigation from '../Navigation';
+import Navigation, { cleanUpTOC, updateTOC } from '../Navigation';
 
-test('renders side navigation', () => {
-  render(<Navigation />);
+const headingClassName = 'tocHeading';
+const headings = ['foo', 'bar'];
+
+const MockFormSections = () => {
+  useEffect(() => {
+    updateTOC();
+    return cleanUpTOC;
+  });
+  return (
+    <div className="tocSection">
+      {headings.map(heading => (
+        <div key={heading} className={headingClassName}>
+          {heading}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+describe('<Navigation/>', () => {
+  test('renders side navigation', () => {
+    render(<Navigation />);
+  });
+
+  test('renders side navigation with table of contents', () => {
+    const { getAllByText } = render(
+      <div>
+        <MockFormSections />
+        <Navigation />
+      </div>
+    );
+
+    headings.forEach(heading => {
+      const allEntries = getAllByText(heading);
+      const navigationEntry = allEntries.filter(entry => entry instanceof HTMLAnchorElement);
+      expect(navigationEntry).toHaveLength(1);
+      expect(navigationEntry[0]).toBeVisible();
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10002,6 +10002,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+tocbot@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/tocbot/-/tocbot-4.10.1.tgz#e1b0264dfe58431d34bf38f1298a4ff4d9dd810b"
+  integrity sha512-ej63EeK+iB3uWt9zekBWv52r7bH9hnVJIOCLwpwXPj0XeAgJFQ3NtVa252kPbSmhrGADuHpCwgcIaaIYtRr+dw==
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"


### PR DESCRIPTION
# Summary

Adds a sidebar with a list of sections that can be clicked to jump to that section.

_Note: This PR is based off of #19 instead of master to illustrate the list of sections.  Happy to submit one off master if desired._

![Screen Shot 2020-03-19 at 12 07 57 AM](https://user-images.githubusercontent.com/41651655/77030738-02aa6400-6976-11ea-8bee-a172a99e2d22.png)

# Code Changes
* Updated the `Navigation` component to use tocbot for displaying the list of sections and stick.
* Added the `nowrap` option to `App` to prevent a long form from wrapping and putting the header to the side
* Added an `id` to the `FormSectionHeader` to support jumping to the section with tocbot
* Added a `useEffect` hook to `FormContent` to initialize and update the sidebar

# Testing Guidance
Run tests and lint.

Editing the page to make the Form sections really long and simulate the length of a longer form will make testing the jump to section functionality easier to see.